### PR TITLE
feat: implement homepage trust indicators bar (PRP-017)

### DIFF
--- a/public/images/trust/bbb-rating.svg
+++ b/public/images/trust/bbb-rating.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="80" viewBox="0 0 100 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="80" rx="8" fill="#1B3A6F"/>
+  <text x="50" y="35" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">BBB</text>
+  <text x="50" y="55" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#FFD700" text-anchor="middle">A+</text>
+</svg>

--- a/public/images/trust/equal-housing.svg
+++ b/public/images/trust/equal-housing.svg
@@ -1,0 +1,6 @@
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="60" height="60" fill="#000000"/>
+  <rect x="15" y="25" width="30" height="25" fill="white"/>
+  <polygon points="30,15 45,25 15,25" fill="white"/>
+  <rect x="25" y="35" width="10" height="15" fill="#000000"/>
+</svg>

--- a/public/images/trust/va-approved.svg
+++ b/public/images/trust/va-approved.svg
@@ -1,0 +1,5 @@
+<svg width="120" height="80" viewBox="0 0 120 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="80" rx="8" fill="#003E73"/>
+  <text x="60" y="35" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">VA APPROVED</text>
+  <text x="60" y="55" font-family="Arial, sans-serif" font-size="12" fill="white" text-anchor="middle">LENDER</text>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,3 +231,14 @@
     }
   }
 }
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.scrollbar-hide {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { HeroSection } from '@/components/layout/hero/HeroSection'
+import { TrustBar } from '@/components/home/TrustBar'
 import { BenefitsGrid } from '@/components/home/BenefitsGrid'
 import { ReviewsSection } from '@/components/reviews/ReviewsSection'
 
@@ -6,6 +7,9 @@ export default function HomePage() {
   return (
     <main className="min-h-screen">
       <HeroSection />
+      
+      {/* Trust Indicators Bar */}
+      <TrustBar />
       
       {/* Benefits Grid Section */}
       <BenefitsGrid />

--- a/src/components/home/TrustBar/TrustBar.tsx
+++ b/src/components/home/TrustBar/TrustBar.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { TrustIndicator } from './TrustIndicator'
+import { trustIndicators } from './trust-data'
+import { cn } from '@/lib/utils'
+
+export function TrustBar() {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    // Trigger fade-in animation after mount
+    const timer = setTimeout(() => setIsVisible(true), 100)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <section 
+      className={cn(
+        "bg-gray-50 border-y border-gray-200 transition-opacity duration-1000",
+        isVisible ? "opacity-100" : "opacity-0"
+      )}
+      aria-label="Trust and Compliance Information"
+    >
+      <div className="container mx-auto px-4 py-6">
+        {/* Desktop Layout */}
+        <div className="hidden md:flex items-center justify-between divide-x divide-gray-300">
+          {trustIndicators.map((indicator) => (
+            <TrustIndicator
+              key={indicator.id}
+              {...indicator}
+              className="flex-1"
+            />
+          ))}
+        </div>
+
+        {/* Mobile Layout - Horizontal Scroll */}
+        <div className="md:hidden overflow-x-auto scrollbar-hide">
+          <div className="flex items-center min-w-max divide-x divide-gray-300">
+            {trustIndicators.map((indicator) => (
+              <TrustIndicator
+                key={indicator.id}
+                {...indicator}
+                className="flex-shrink-0"
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Compliance Text */}
+        <div className="mt-4 text-center">
+          <p className="text-xs text-gray-500">
+            Licensed in all 50 states. NMLS# 123456. Equal Housing Opportunity Lender.
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/TrustBar/TrustIndicator.tsx
+++ b/src/components/home/TrustBar/TrustIndicator.tsx
@@ -1,0 +1,86 @@
+import Image from 'next/image'
+import { cn } from '@/lib/utils'
+
+interface TrustIndicatorProps {
+  type: 'text' | 'image' | 'badge'
+  label: string
+  value?: string
+  imageSrc?: string
+  imageAlt?: string
+  ariaLabel: string
+  className?: string
+}
+
+export function TrustIndicator({
+  type,
+  label,
+  value,
+  imageSrc,
+  imageAlt,
+  ariaLabel,
+  className
+}: TrustIndicatorProps) {
+  // Text-based indicator (NMLS, Years)
+  if (type === 'text') {
+    return (
+      <div 
+        className={cn(
+          "flex flex-col items-center justify-center px-4",
+          className
+        )}
+        aria-label={ariaLabel}
+      >
+        <span className="text-sm text-gray-600 font-medium">{label}</span>
+        <span className="text-lg font-bold text-gray-900">{value}</span>
+      </div>
+    )
+  }
+
+  // Badge indicator (VA Approved, BBB)
+  if (type === 'badge' && imageSrc) {
+    return (
+      <div 
+        className={cn(
+          "flex items-center justify-center px-4",
+          className
+        )}
+        aria-label={ariaLabel}
+      >
+        <Image
+          src={imageSrc}
+          alt={imageAlt || label}
+          width={80}
+          height={60}
+          className="h-12 w-auto object-contain"
+          loading="eager"
+          priority
+        />
+      </div>
+    )
+  }
+
+  // Image indicator (Equal Housing)
+  if (type === 'image' && imageSrc) {
+    return (
+      <div 
+        className={cn(
+          "flex items-center justify-center px-4",
+          className
+        )}
+        aria-label={ariaLabel}
+      >
+        <Image
+          src={imageSrc}
+          alt={imageAlt || label}
+          width={60}
+          height={60}
+          className="h-10 w-auto object-contain"
+          loading="eager"
+          priority
+        />
+      </div>
+    )
+  }
+
+  return null
+}

--- a/src/components/home/TrustBar/index.ts
+++ b/src/components/home/TrustBar/index.ts
@@ -1,0 +1,4 @@
+export { TrustBar } from './TrustBar'
+export { TrustIndicator } from './TrustIndicator'
+export { trustIndicators } from './trust-data'
+export type { TrustIndicator as TrustIndicatorType } from './trust-data'

--- a/src/components/home/TrustBar/trust-data.ts
+++ b/src/components/home/TrustBar/trust-data.ts
@@ -1,0 +1,50 @@
+export interface TrustIndicator {
+  id: string
+  type: 'text' | 'image' | 'badge'
+  label: string
+  value?: string
+  imageSrc?: string
+  imageAlt?: string
+  ariaLabel: string
+}
+
+export const trustIndicators: TrustIndicator[] = [
+  {
+    id: 'va-approved',
+    type: 'badge',
+    label: 'VA Approved',
+    imageSrc: '/images/trust/va-approved.svg',
+    imageAlt: 'VA Approved Lender',
+    ariaLabel: 'Veterans Affairs Approved Lender'
+  },
+  {
+    id: 'nmls',
+    type: 'text',
+    label: 'NMLS',
+    value: '#123456',
+    ariaLabel: 'NMLS Number 123456'
+  },
+  {
+    id: 'years',
+    type: 'text',
+    label: 'Serving Veterans',
+    value: '15+ Years',
+    ariaLabel: 'Serving Veterans for Over 15 Years'
+  },
+  {
+    id: 'bbb',
+    type: 'badge',
+    label: 'BBB Rating',
+    imageSrc: '/images/trust/bbb-rating.svg',
+    imageAlt: 'A+ BBB Rating',
+    ariaLabel: 'Better Business Bureau A Plus Rating'
+  },
+  {
+    id: 'equal-housing',
+    type: 'image',
+    label: 'Equal Housing Lender',
+    imageSrc: '/images/trust/equal-housing.svg',
+    imageAlt: 'Equal Housing Lender',
+    ariaLabel: 'Equal Housing Opportunity Lender'
+  }
+]


### PR DESCRIPTION
  ## Summary
  Implements Homepage Trust Indicators Bar as specified in PRP-017 and US-017.

  ## What's Changed
  - Added TrustBar component with 5 trust indicators to build immediate credibility
  - Implemented responsive layout (horizontal on desktop/tablet, horizontal scroll on mobile)
  - Added fade-in animation on component mount for subtle visual appeal
  - Created trust indicators: VA approved badge, NMLS#, years in business, BBB rating, Equal Housing logo
  - Added placeholder SVG assets for badges (to be replaced with licensed versions)
  - Updated globals.css with scrollbar-hide utility for clean mobile experience
  - Integrated trust bar into homepage between hero section and benefits grid

  ## Testing
  - [x] Responsive layout tested on desktop, tablet, and mobile viewports
  - [x] Fade-in animation triggers correctly on mount
  - [x] Mobile horizontal scroll works smoothly
  - [x] Build completes successfully
  - [x] No TypeScript or ESLint errors

  ## Related Issues
  - Implements US-017: Homepage Trust Indicators Bar
  - Completes PRP-017

  ## Notes
  - SVG badges are placeholders and need to be replaced with properly licensed assets before production
  - NMLS number (#123456) is placeholder and needs to be updated with actual number
  - Consider A/B testing the trust bar placement and content for optimal conversion impact
