### PR TITLE
feat: add homepage final CTA section (PRP-022)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,6 +104,13 @@
     linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
 }
 
+/* Grid background pattern */
+.bg-grid-white\/5 {
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 64px 64px;
+}
+
 /* Smooth number animations */
 @keyframes countUp {
   from {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { AffordabilityPreview } from '@/components/home/AffordabilityPreview'
 import { LoanComparison } from '@/components/home/LoanComparison'
 import { EducationalResources } from '@/components/home/EducationalResources'
 import { ReviewsSection } from '@/components/reviews/ReviewsSection'
+import { FinalCTA } from '@/components/home/FinalCTA'
 
 export default function HomePage() {
   return (
@@ -33,14 +34,8 @@ export default function HomePage() {
       {/* Reviews Section */}
       <ReviewsSection />
       
-      {/* Placeholder for future sections */}
-      <section className="py-16 bg-white">
-        <div className="container mx-auto px-4">
-          <h2 className="text-3xl font-bold text-center mb-8">
-            More content coming soon...
-          </h2>
-        </div>
-      </section>
+      {/* Final CTA Section */}
+      <FinalCTA />
     </main>
   )
 }

--- a/src/components/home/FinalCTA/FinalCTA.tsx
+++ b/src/components/home/FinalCTA/FinalCTA.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useInView } from '@/hooks/useInView'
+import { Button } from '@/components/ui/button'
+import { ctaOptions, trustIndicators, valueProps } from './cta-data'
+import { ArrowRight, CheckCircle } from 'lucide-react'
+import Link from 'next/link'
+
+export function FinalCTA() {
+  const { ref, inView } = useInView<HTMLDivElement>({
+    threshold: 0.3,
+    triggerOnce: true
+  })
+
+  // Track analytics when section comes into view
+  useEffect(() => {
+    if (inView && typeof window !== 'undefined' && window.gtag) {
+      window.gtag('event', 'view_final_cta', {
+        event_category: 'Homepage',
+        event_label: 'Final CTA Section Viewed'
+      })
+    }
+  }, [inView])
+
+  const handleCTAClick = (tracking: { event: string; label: string }) => {
+    if (typeof window !== 'undefined' && window.gtag) {
+      window.gtag('event', tracking.event, {
+        event_category: 'Homepage',
+        event_label: tracking.label
+      })
+    }
+  }
+
+  return (
+    <section 
+      ref={ref}
+      className="relative py-20 bg-gradient-to-br from-va-blue to-va-blue/90 overflow-hidden"
+      aria-label="Get Started with Your VA Loan"
+    >
+      {/* Background Pattern */}
+      <div className="absolute inset-0 bg-grid-white/5" />
+      
+      <div className="container mx-auto px-4 relative z-10">
+        <div className="max-w-4xl mx-auto text-center">
+          {/* Headline */}
+          <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6">
+            Ready to Use Your VA Loan Benefit?
+          </h2>
+          
+          {/* Value Props */}
+          <div className="flex flex-wrap justify-center gap-4 mb-8">
+            {valueProps.map((prop) => (
+              <div key={prop} className="flex items-center gap-2 text-white/90">
+                <CheckCircle className="w-5 h-5 text-va-gold" />
+                <span className="text-lg">{prop}</span>
+              </div>
+            ))}
+          </div>
+          
+          {/* Subheadline */}
+          <p className="text-xl text-white/90 mb-10 max-w-2xl mx-auto">
+            Join over 50,000 veterans who've achieved homeownership with our help. 
+            Start your journey today with no obligation.
+          </p>
+          
+          {/* Primary CTAs */}
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
+            {ctaOptions.filter(cta => cta.type === 'primary' || cta.type === 'secondary').map((cta) => {
+              const Icon = cta.icon
+              const isPrimary = cta.type === 'primary'
+              
+              return (
+                <Link
+                  key={cta.id}
+                  href={cta.href || '#'}
+                  onClick={() => handleCTAClick(cta.tracking)}
+                  className="group"
+                >
+                  <Button
+                    size="lg"
+                    variant={isPrimary ? 'default' : 'secondary'}
+                    className={`
+                      ${isPrimary 
+                        ? 'bg-va-gold text-va-blue hover:bg-va-gold/90 shadow-lg' 
+                        : 'bg-white text-va-blue hover:bg-gray-100'
+                      } 
+                      px-8 py-6 text-lg h-auto flex-col sm:flex-row gap-1
+                    `}
+                  >
+                    <span className="flex items-center gap-2">
+                      {Icon && <Icon className="w-5 h-5" />}
+                      {cta.label}
+                    </span>
+                    {cta.sublabel && (
+                      <span className="text-sm opacity-80 font-normal">
+                        {cta.sublabel}
+                      </span>
+                    )}
+                    {isPrimary && <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />}
+                  </Button>
+                </Link>
+              )
+            })}
+          </div>
+          
+          {/* Secondary CTAs */}
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-10">
+            {ctaOptions.filter(cta => cta.type === 'tertiary').map((cta) => {
+              const Icon = cta.icon
+              
+              return (
+                <Link
+                  key={cta.id}
+                  href={cta.href || '#'}
+                  onClick={() => handleCTAClick(cta.tracking)}
+                  className="inline-flex items-center gap-2 text-white hover:text-va-gold transition-colors"
+                >
+                  {Icon && <Icon className="w-5 h-5" />}
+                  <span className="underline underline-offset-4">
+                    {cta.label}
+                  </span>
+                </Link>
+              )
+            })}
+          </div>
+          
+          {/* Trust Indicators */}
+          <div className="flex flex-wrap justify-center gap-6 text-white/80 text-sm">
+            {trustIndicators.map((indicator) => (
+              <div key={indicator.id} className="flex items-center gap-2">
+                <span className="text-va-gold">{indicator.icon}</span>
+                <span>{indicator.text}</span>
+              </div>
+            ))}
+          </div>
+          
+          {/* Operating Hours */}
+          <div className="mt-8 text-white/70 text-sm">
+            <p>Available Monday-Friday 8am-8pm EST, Saturday 9am-5pm EST</p>
+            <p className="mt-2">
+              Questions? Email us at{' '}
+              <a href="mailto:support@vahomeloans.com" className="underline hover:text-white">
+                support@vahomeloans.com
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+      
+      {/* Decorative Elements */}
+      <div className="absolute top-0 right-0 w-64 h-64 bg-va-gold/10 rounded-full blur-3xl" />
+      <div className="absolute bottom-0 left-0 w-96 h-96 bg-white/5 rounded-full blur-3xl" />
+    </section>
+  )
+}

--- a/src/components/home/FinalCTA/cta-data.ts
+++ b/src/components/home/FinalCTA/cta-data.ts
@@ -1,0 +1,94 @@
+import { Phone, Calendar, Download } from 'lucide-react'
+import { LucideIcon } from 'lucide-react'
+
+export interface CTAOption {
+  id: string
+  type: 'primary' | 'secondary' | 'tertiary'
+  label: string
+  sublabel?: string
+  href?: string
+  onClick?: () => void
+  icon?: LucideIcon
+  tracking: {
+    event: string
+    label: string
+  }
+}
+
+export const ctaOptions: CTAOption[] = [
+  {
+    id: 'get-quote',
+    type: 'primary',
+    label: 'Get Your Free Quote',
+    sublabel: 'No obligation • 2-minute form',
+    href: '/get-started',
+    tracking: {
+      event: 'click_final_cta_quote',
+      label: 'Final CTA - Get Quote'
+    }
+  },
+  {
+    id: 'call-now',
+    type: 'secondary',
+    label: 'Call 1-800-VA-LOANS',
+    sublabel: 'Speak to a VA loan specialist',
+    href: 'tel:1-800-825-6267',
+    icon: Phone,
+    tracking: {
+      event: 'click_final_cta_call',
+      label: 'Final CTA - Call Now'
+    }
+  },
+  {
+    id: 'schedule-call',
+    type: 'tertiary',
+    label: 'Schedule a Call',
+    href: '/schedule-consultation',
+    icon: Calendar,
+    tracking: {
+      event: 'click_final_cta_schedule',
+      label: 'Final CTA - Schedule Call'
+    }
+  },
+  {
+    id: 'download-guide',
+    type: 'tertiary',
+    label: 'Download VA Loan Guide',
+    href: '/resources/va-loan-guide',
+    icon: Download,
+    tracking: {
+      event: 'click_final_cta_download',
+      label: 'Final CTA - Download Guide'
+    }
+  }
+]
+
+export const trustIndicators = [
+  {
+    id: 'no-obligation',
+    text: 'No Obligation Quote',
+    icon: '✓'
+  },
+  {
+    id: 'fast-response',
+    text: '15-Minute Response Time',
+    icon: '⚡'
+  },
+  {
+    id: 'va-experts',
+    text: 'VA Loan Experts',
+    icon: '🎖️'
+  },
+  {
+    id: 'secure',
+    text: 'Secure & Confidential',
+    icon: '🔒'
+  }
+]
+
+export const valueProps = [
+  '$0 Down Payment',
+  'No PMI Required',
+  'Competitive Rates',
+  'Flexible Credit Requirements'
+]

--- a/src/components/home/FinalCTA/index.ts
+++ b/src/components/home/FinalCTA/index.ts
@@ -1,0 +1,2 @@
+export { FinalCTA } from './FinalCTA'
+export { ctaOptions, trustIndicators, valueProps } from './cta-data'


### PR DESCRIPTION
## Summary
- Implemented homepage final CTA section as specified in PRP-022
- Created compelling conversion-focused section with multiple pathways
- Added prominent trust indicators and value propositions

## Implementation Details
- Created CTAOption interface with tracking configuration
- Built FinalCTA component with gradient background and decorative elements
- Implemented 4 CTA types: primary quote, secondary call, tertiary schedule/download
- Added trust indicators (no obligation, fast response, VA experts, secure)
- Integrated comprehensive analytics tracking for all interactions

## Components Created
- `FinalCTA.tsx` - Main section component with visual design
- `cta-data.ts` - CTA configuration and trust indicator data
- Added `bg-grid-white/5` utility to globals.css for grid pattern

## Features
- Primary CTA: Get Free Quote with no-obligation messaging
- Secondary CTA: Click-to-call with VA loan specialist sublabel
- Tertiary CTAs: Schedule call and download guide links
- 4 value propositions with check icons
- 4 trust indicators with visual icons
- Operating hours and email contact information
- Gradient background with blur decorative elements
- Full responsive design with proper button stacking on mobile

## Visual Design
- VA blue gradient background (from-va-blue to-va-blue/90)
- VA gold accents for primary CTA and trust indicators
- White secondary buttons for contrast
- Decorative blur elements for visual interest
- Grid pattern overlay for texture

## Testing
- ✅ TypeScript type checking passed
- ✅ ESLint validation passed (removed unused import)
- ✅ Next.js build successful

## Analytics Events
- `view_final_cta` - Section view tracking
- `click_final_cta_quote` - Primary quote CTA
- `click_final_cta_call` - Phone call CTA
- `click_final_cta_schedule` - Schedule consultation CTA
- `click_final_cta_download` - Download guide CTA

🤖 Generated with [Claude Code](https://claude.ai/code)