### PR TITLE
Enable simplified hero section feature flag

### DIFF
--- a/src/lib/feature-flags/hero-simplification.ts
+++ b/src/lib/feature-flags/hero-simplification.ts
@@ -5,8 +5,8 @@ export const heroSimplificationFlag: FeatureFlag = {
   key: 'hero-simplification',
   name: 'Hero Section Simplification',
   description: 'Simplified hero section with extracted components',
-  defaultValue: false,
-  rolloutPercentage: 0, // Start with 0%, increase gradually
+  defaultValue: true,
+  rolloutPercentage: 100, // Enable for all users
   trackingEvents: {
     viewed: 'hero_simplification_viewed',
     ctaClicked: 'hero_simplification_cta_clicked',


### PR DESCRIPTION
## Summary
This PR enables the simplified hero section design by updating the feature flag configuration.

## Changes
- Set `defaultValue` to `true` in hero-simplification feature flag
- Set `rolloutPercentage` to `100%` to enable for all users

## Why
The previous deployment at https://ultimate-va-loans-frontend-mqtfaahnj.vercel.app/ was still showing the old complex hero section because the feature flag was disabled. This change enables the new simplified hero that matches the reference design.

## Impact
Once deployed, all users will see the new simplified hero section with:
- Cleaner layout
- Better visual hierarchy
- Improved focus on the main CTA
- Removal of complex trust badges and animations

🤖 Generated with [Claude Code](https://claude.ai/code)